### PR TITLE
delete wpa key when connecting to open networks

### DIFF
--- a/wireless
+++ b/wireless
@@ -120,7 +120,7 @@ sub configure_wlan {
 	my ($interface, $nwid, $wpakey,$type) = @_; 
 	print "Configuring SSID $nwid on $interface\n";
 	if(lc($type) eq 'open'){
-		system("ifconfig $interface nwid \"$nwid\"");
+		system("ifconfig $interface nwid \"$nwid\" -wpakey");
 	} elsif(lc($type) eq 'wpa'){
 		system("ifconfig $interface nwid \"$nwid\" wpakey \"$wpakey\"");
 	} else {


### PR DESCRIPTION
When connecting to open wireless networks, delete the pre-shared WPA key and disable WPA. This allows switching back and forth between open and WPA networks.
